### PR TITLE
Umat initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /dev/
 /docs/build/
 /docs/site/
+/deps/usr
+/deps/build.log
+/deps/build_umat_binaries*
+/deps/deps.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: julia
 os:
   - linux
+  - osx
+  - windows
 julia:
   - 1.0
   - 1.3

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,11 @@ uuid = "d4351ba0-2d5c-4db0-b06c-903428c7bcf5"
 authors = ["Tero Frondelius", "Ivan Yashchuk"]
 version = "0.1.0"
 
+[deps]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,16 @@ version = "0.1.0"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Materials = "35fa313e-aa48-52ea-bc82-ddb91c7db87b"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
 julia = "1"
+Materials = ">= 0.2.0"
 
 [extras]
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Suppressor", "Test"]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,11 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
+
+dependencies = [
+    "https://github.com/TeroFrondelius/umat_binaries_builder/releases/download/v0.1.0/build_umat_binaries.v0.1.0.jl"
+]
+
+for build_script in dependencies
+    script_name = split(build_script,"/")[end]
+    include(download(build_script,script_name))
+end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@
 # License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
 
 dependencies = [
-    "https://github.com/TeroFrondelius/umat_binaries_builder/releases/download/v0.1.0/build_umat_binaries.v0.1.0.jl"
+    "https://github.com/TeroFrondelius/umat_binaries_builder/releases/download/v0.3.2/build_umat_binaries.v0.1.0.jl"
 ]
 
 for build_script in dependencies

--- a/src/UMAT.jl
+++ b/src/UMAT.jl
@@ -12,8 +12,8 @@ using LinearAlgebra
 # TODO: Need to find the way how to set them and modify default state variables from user code
 #       so that `reset_material!` and `update_material!` work correctly
 NTENS = 6
-NSTATV = 13
-NPROPS = 1
+NSTATV = 0#13
+NPROPS = 0#3 # PROPS(1) - E, PROPS(2) - NU, PROPS(3) - SYIELD
 
 # Documentation for every variable can be found in Abaqus doc about UMAT online.
 

--- a/src/UMAT.jl
+++ b/src/UMAT.jl
@@ -1,6 +1,11 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
+
 module UMAT
 
 using Libdl
+using Materials
+using Parameters
 using LinearAlgebra
 
 # These numbers are specific to the chosen umat
@@ -138,4 +143,5 @@ function integrate_material!(material::UmatMaterial)
     material.variables_new = variables_new
 end
 
+export UmatMaterial, UmatDriverState, UmatParameterState, UmatVariableState, UmatOtherState
 end # module

--- a/src/UMAT.jl
+++ b/src/UMAT.jl
@@ -1,5 +1,141 @@
 module UMAT
 
-greet() = print("Hello World!")
+using Libdl
+using LinearAlgebra
+
+# These numbers are specific to the chosen umat
+# TODO: Need to find the way how to set them and modify default state variables from user code
+#       so that `reset_material!` and `update_material!` work correctly
+NTENS = 6
+NSTATV = 13
+NPROPS = 1
+
+# Documentation for every variable can be found in Abaqus doc about UMAT online.
+
+"""
+Variables updated by UMAT routine.
+"""
+@with_kw struct UmatVariableState <: AbstractMaterialState
+    DDSDDE :: Array{Float64,2} = zeros(Float64, NTENS, NTENS)
+    STRESS :: Array{Float64,1} = zeros(Float64, NTENS)
+    STATEV :: Array{Float64,1} = zeros(Float64, NSTATV)
+    SSE :: Array{Float64,1} = zeros(Float64, 1)
+    SPD :: Array{Float64,1} = zeros(Float64, 1)
+    SCD :: Array{Float64,1} = zeros(Float64, 1)
+    RPL :: Array{Float64,1} = zeros(Float64, 1)
+    DDSDDT :: Array{Float64,1} = zeros(Float64, NTENS)
+    DRPLDE :: Array{Float64,1} = zeros(Float64, NTENS)
+    DRPLDT :: Array{Float64,1} = zeros(Float64, 1)
+    PNEWDT :: Array{Float64,1} = ones(Float64, 1)
+end
+
+"""
+Material parameters in order that is specific to chosen UMAT.
+"""
+@with_kw struct UmatParameterState <: AbstractMaterialState
+    PROPS :: Array{Float64,1} = zeros(Float64, NPROPS)
+end
+
+"""
+Variables passed in for information.
+These drive evolution of the material state.
+"""
+@with_kw struct UmatDriverState <: AbstractMaterialState
+    STRAN :: Array{Float64,1} = zeros(Float64, NTENS)
+    TIME :: Array{Float64,1} = zeros(Float64, 2)
+    TEMP :: Float64 = zero(Float64)
+    PREDEF :: Float64 = zero(Float64)
+end
+
+"""
+Other Abaqus UMAT variables passed in for information.
+"""
+@with_kw struct UmatOtherState <: AbstractMaterialState
+    CMNAME :: Cuchar = 'U'
+    NDI :: Int64 = 3
+    NSHR :: Int64 = 3
+    NTENS :: Int64 = NTENS # NDI + NSHR
+    NSTATV :: Int64 = NSTATV #zero(Int64)
+    NPROPS :: Int64 = NPROPS #zero(Int64)
+    COORDS :: Array{Float64,1} = zeros(Float64, 3)
+    DROT :: Array{Float64,2} = I + zeros(Float64, 3, 3)
+    CELENT :: Float64 = zero(Float64)
+    DFGRD0 :: Array{Float64,2} = I + zeros(Float64, 3, 3)
+    DFGRD1 :: Array{Float64,2} = I + zeros(Float64, 3, 3)
+    NOEL :: Int64 = zero(Int64)
+    NPT :: Int64 = zero(Int64)
+    LAYER :: Int64 = zero(Int64)
+    KSPT :: Int64 = zero(Int64)
+    JSTEP :: Array{Float64,1} = zeros(Int64, 3)
+    KSTEP :: Int64 = zero(Int64)
+    KINC :: Int64 = zero(Int64)
+end
+
+"""
+UMAT material structure.
+
+`lib_path` is the path to the compiled shared library.
+`behaviour` is the function name to call from the shared library
+    generally this is compiler dependent, by default `umat_`.
+    MFront Abaqus interface produces specific name, e.g. `ELASTICITY_3D`.
+"""
+@with_kw mutable struct UmatMaterial <: AbstractMaterial
+    drivers :: UmatDriverState = UmatDriverState()
+    ddrivers :: UmatDriverState = UmatDriverState()
+    variables :: UmatVariableState = UmatVariableState()
+    variables_new :: UmatVariableState = UmatVariableState()
+    parameters :: UmatParameterState = UmatParameterState()
+    dparameters :: UmatParameterState = UmatParameterState()
+
+    umat_other :: UmatOtherState = UmatOtherState()
+
+    lib_path :: String
+    behaviour :: Symbol = :umat_
+end
+
+"""
+Wrapper function to ccall the UMAT subroutine from the compiled shared library.
+"""
+function call_umat!(func_umat::Symbol, lib_path::String, STRESS,STATEV,DDSDDE,SSE,SPD,SCD,RPL,DDSDDT,DRPLDE,DRPLDT,
+        STRAN,DSTRAN,TIME,DTIME,TEMP,DTEMP,PREDEF,DPRED,CMNAME,NDI,NSHR,
+        NTENS,NSTATV,PROPS,NPROPS,COORDS,DROT,PNEWDT,CELENT,DFGRD0,DFGRD1,
+        NOEL,NPT,LAYER,KSPT,KSTEP,KINC)
+
+    lib_umat = Libdl.dlopen(lib_path) # Open the library explicitly.
+    sym_umat = Libdl.dlsym(lib_umat, func_umat) # Get a symbol for the umat function to call.
+
+    ccall(sym_umat, Nothing,
+        (Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},
+        Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Cuchar},Ref{Int64},Ref{Int64},
+        Ref{Int64},Ref{Int64},Ref{Float64},Ref{Int64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},Ref{Float64},
+        Ref{Int64},Ref{Int64},Ref{Int64},Ref{Int64},Ref{Int64},Ref{Int64}),
+        STRESS,STATEV,DDSDDE,SSE,SPD,SCD,RPL,DDSDDT,DRPLDE,DRPLDT,
+        STRAN,DSTRAN,TIME,DTIME,TEMP,DTEMP,PREDEF,DPRED,CMNAME,NDI,NSHR,
+        NTENS,NSTATV,PROPS,NPROPS,COORDS,DROT,PNEWDT,CELENT,DFGRD0,DFGRD1,
+        NOEL,NPT,LAYER,KSPT,KSTEP,KINC)
+
+    Libdl.dlclose(lib_umat) # Close the library explicitly.
+
+    return Nothing
+end
+
+"""
+Calls UMAT and updates MaterialVariableState writing the result to material.variables_new
+"""
+function integrate_material!(material::UmatMaterial)
+    @unpack CMNAME,NDI,NSHR,NTENS,NSTATV,NPROPS,COORDS,DROT,CELENT,DFGRD0,DFGRD1,NOEL,NPT,LAYER,KSPT,KSTEP,KINC = material.umat_other
+    @unpack PROPS = material.parameters
+    STRAN, TIME, TEMP, PREDEF = material.drivers.STRAN, material.drivers.TIME, material.drivers.TEMP, material.drivers.PREDEF
+    DSTRAN, DTIME, DTEMP, DPRED = material.ddrivers.STRAN, material.drivers.TIME[1], material.ddrivers.TEMP, material.ddrivers.PREDEF
+    @unpack STRESS,STATEV,DDSDDE,SSE,SPD,SCD,RPL,DDSDDT,DRPLDE,DRPLDT,PNEWDT = material.variables
+
+    call_umat!(material.behaviour, material.lib_path, STRESS, STATEV, DDSDDE, SSE, SPD, SCD, RPL, DDSDDT, DRPLDE, DRPLDT,
+        STRAN, DSTRAN, TIME, DTIME, TEMP, DTEMP, PREDEF, DPRED, CMNAME, NDI, NSHR,
+        NTENS, NSTATV, PROPS, NPROPS, COORDS, DROT, PNEWDT, CELENT, DFGRD0, DFGRD1,
+        NOEL, NPT, LAYER, KSPT, KSTEP, KINC)
+
+    variables_new = UmatVariableState(STRESS=STRESS,STATEV=STATEV,DDSDDE=DDSDDE,SSE=SSE,SPD=SPD,SCD=SCD,RPL=RPL,DDSDDT=DDSDDT,DRPLDE=DRPLDE,DRPLDT=DRPLDT,PNEWDT=PNEWDT)
+    material.variables_new = variables_new
+end
 
 end # module

--- a/src/UMAT.jl
+++ b/src/UMAT.jl
@@ -11,7 +11,7 @@ using LinearAlgebra
 # These numbers are specific to the chosen umat
 # TODO: Need to find the way how to set them and modify default state variables from user code
 #       so that `reset_material!` and `update_material!` work correctly
-NTENS = 6
+NTENS = 4 #6
 NSTATV = 0#13
 NPROPS = 0#3 # PROPS(1) - E, PROPS(2) - NU, PROPS(3) - SYIELD
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ using Suppressor
     @testset "Binary dependencies" begin
         include("test_binary_dependencies.jl")
     end
+    @testset "libelastic.so" begin
+        include("test_elastic.jl")
+    end
     @testset "UmatMaterial" begin
         include("test_umatmaterial.jl")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,16 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
+
 using UMAT
 using Test
+using Suppressor
+
 
 @testset "UMAT.jl" begin
-    # Write your own tests here.
+    @testset "Binary dependencies" begin
+        include("test_binary_dependencies.jl")
+    end
+    @testset "UmatMaterial" begin
+        include("test_umatmaterial.jl")
+    end
 end

--- a/test/test_binary_dependencies.jl
+++ b/test/test_binary_dependencies.jl
@@ -1,10 +1,16 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
 
+using Test, Libdl
+
 pkg_dir = dirname(Base.find_package("UMAT"))
-usr_dir = joinpath(pkg_dir,"..","deps","usr")
 if Sys.iswindows()
-    @test isfile(joinpath(usr_dir,"bin","libmises_umat.dll"))
+    lib_dir = joinpath(pkg_dir,"..","deps","usr","bin")
 else
-    @test isfile(joinpath(usr_dir,"lib","libmises_umat.so"))
+    lib_dir = joinpath(pkg_dir,"..","deps","usr","lib")
 end
+
+@test isfile(joinpath(lib_dir,"libelastic." * dlext))
+@test isfile(joinpath(lib_dir,"libisotropic_plast_exp." * dlext))
+@test isfile(joinpath(lib_dir,"libisotropic_plast_imp." * dlext))
+@test isfile(joinpath(lib_dir,"libmises_umat." * dlext))

--- a/test/test_binary_dependencies.jl
+++ b/test/test_binary_dependencies.jl
@@ -1,0 +1,10 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
+
+pkg_dir = dirname(Base.find_package("UMAT"))
+usr_dir = joinpath(pkg_dir,"..","deps","usr")
+if Sys.iswindows()
+    @test isfile(joinpath(usr_dir,"bin","libmises_umat.dll"))
+else
+    @test isfile(joinpath(usr_dir,"lib","libmises_umat.so"))
+end

--- a/test/test_elastic.jl
+++ b/test/test_elastic.jl
@@ -1,0 +1,25 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
+
+using UMAT, Test, Materials, Libdl
+
+pkg_dir = dirname(Base.find_package("UMAT"))
+if Sys.iswindows()
+    lib_dir = joinpath(pkg_dir,"..","deps","usr","bin")
+else
+    lib_dir = joinpath(pkg_dir,"..","deps","usr","lib")
+end
+
+material = UmatMaterial(lib_path=joinpath(lib_dir,"libelastic." * dlext),
+                        behaviour=:umat_)
+
+strains = [1.0e-3, 0.0, 0.0, 0.0, 0.0, 0.0]
+material.ddrivers = UmatDriverState(STRAN = strains)
+UMAT.integrate_material!(material)
+update_material!(material)
+
+
+@test isapprox(material.variables.STRESS[1],210.)
+for i in 2:6
+    @test isapprox(material.variables.STRESS[i],0.0)
+end

--- a/test/test_elastic.jl
+++ b/test/test_elastic.jl
@@ -10,16 +10,14 @@ else
     lib_dir = joinpath(pkg_dir,"..","deps","usr","lib")
 end
 
-material = UmatMaterial(lib_path=joinpath(lib_dir,"libelastic." * dlext),
-                        behaviour=:umat_)
+material = UmatMaterial(lib_path=joinpath(lib_dir,"libelastic." * dlext))
 
-strains = [1.0e-3, 0.0, 0.0, 0.0, 0.0, 0.0]
+strains = [1.0e-3, 0.0, 0.0, 0.0]
+ref_stress = [282.6923171355886, 121.1538570784259, 121.1538570784259, 0.0]
 material.ddrivers = UmatDriverState(STRAN = strains)
 UMAT.integrate_material!(material)
 update_material!(material)
 
-
-@test isapprox(material.variables.STRESS[1],210.)
-for i in 2:6
-    @test isapprox(material.variables.STRESS[i],0.0)
+for i in 1:4
+    @test isapprox(material.variables.STRESS[i],ref_stress[i],atol=sqrt(eps()))
 end

--- a/test/test_umatmaterial.jl
+++ b/test/test_umatmaterial.jl
@@ -1,12 +1,17 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
 
-using UMAT, Test
+using UMAT, Test, Materials, Libdl
 
 pkg_dir = dirname(Base.find_package("UMAT"))
-usr_dir = joinpath(pkg_dir,"..","deps","usr")
-
-if !Sys.iswindows()
-    material = UmatMaterial(lib_path=joinpath(usr_dir,"lib","libmises_umat.so"),
-                            behaviour=:mises_umat_)
+if Sys.iswindows()
+    lib_dir = joinpath(pkg_dir,"..","deps","usr","bin")
+else
+    lib_dir = joinpath(pkg_dir,"..","deps","usr","lib")
 end
+
+E = 160e9; NU = 0.3; SYIELD = 100
+parameters = UmatParameterState([E, NU, SYIELD])
+material = UmatMaterial(parameters=parameters,
+                        lib_path=joinpath(lib_dir,"libmises_umat." * dlext),
+                        behaviour=:mises_umat_)

--- a/test/test_umatmaterial.jl
+++ b/test/test_umatmaterial.jl
@@ -1,0 +1,12 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/UMAT.jl/blob/master/LICENSE
+
+using UMAT, Test
+
+pkg_dir = dirname(Base.find_package("UMAT"))
+usr_dir = joinpath(pkg_dir,"..","deps","usr")
+
+if !Sys.iswindows()
+    material = UmatMaterial(lib_path=joinpath(usr_dir,"lib","libmises_umat.so"),
+                            behaviour=:mises_umat_)
+end


### PR DESCRIPTION
This work bases @IvanYashchuk pull request: https://github.com/JuliaFEM/Materials.jl/pull/47

> Here is the [demo](https://nbviewer.jupyter.org/urls/gist.githubusercontent.com/IvanYashchuk/209027472524c69b9ce43a4cbc385db6/raw/e0c562a419055c86a247935ef73b82546aeef525/umat-mfront-material-point.ipynb) with predefined strain history for one material/integration point.
> Here is [another notebook](https://nbviewer.jupyter.org/urls/gist.githubusercontent.com/IvanYashchuk/209027472524c69b9ce43a4cbc385db6/raw/e0c562a419055c86a247935ef73b82546aeef525/umat-mfront-mecamatso.ipynb) showing that with suitable changes to mecamatso.jl and FEMMaterials.jl this material routine is working for one element uniaxial displacement.

Will close #1 and #2